### PR TITLE
Add Linux support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,8 +407,16 @@ if (NOT MSVC)
 			-pthread
 			-fvisibility=hidden
 			-fvisibility-inlines-hidden
-			"-Wa,-mbig-obj"
 	)
+	if (CMAKE_COMPILER_IS_GNUCXX)
+		include(CheckCXXCompilerFlag)
+		check_cxx_compiler_flag("-Wa,-mbig-obj" HAS_BIG_OBJ_FLAG)
+		if (HAS_BIG_OBJ_FLAG) # "-Wa,-mbig-obj" is not supported by gcc on Linux
+			target_compile_options (${TARGET} PRIVATE
+					"-Wa,-mbig-obj"
+			)
+		endif ()
+	endif ()
 	if (NOT (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") AND WIN32))
 		target_compile_options (juce PRIVATE -fPIC)
 	endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ if (NOT MSVC)
 			"-Wa,-mbig-obj"
 	)
 	if (NOT (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") AND WIN32))
-		target_compile_options (${TARGET} PRIVATE -fPIC)
+		target_compile_options (juce PRIVATE -fPIC)
 	endif ()
 	target_link_options (juce PRIVATE
 			-shared
@@ -435,7 +435,7 @@ if (NOT MSVC)
 			-ldxgi
 		)
 		if (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
-			target_link_libraries (${TARGET} PRIVATE -s)
+			target_link_libraries (juce PRIVATE -s)
 		endif ()
 	elseif (UNIX AND NOT APPLE)
 		target_link_libraries (juce PRIVATE


### PR DESCRIPTION
在非MSVC的编译器中只有GCC支持`-Wa,-mbig-obj`选项，且也只在某些平台（不包括Linux）上支持。所以加入了检查编译器具体种类和是否支持此选项的逻辑防止在Linux上构建错误。